### PR TITLE
Fix/cliente-ciudad-tests

### DIFF
--- a/app/tests_integration.py
+++ b/app/tests_integration.py
@@ -156,6 +156,23 @@ class ClientsTest(TestCase):
         self.assertEqual(str(editedClient.phone), "54221456789")
         self.assertEqual(editedClient.city, "Berisso")
 
+    def test_create_user_with_invalid_data_test_city(self):
+        """
+        Se testea la función crear con datos de ciudad invalido.
+        """
+
+        response = self.client.post(
+            reverse("clients_form"),
+            data={
+                "name": "Juan Sebastian Veron",
+                "phone": "54221456789",
+                "city": "Rosario",
+                "email": "brujita75@vetsoft.com",
+            },
+        )
+
+        self.assertContains(response, "Por favor ingrese una ciudad valida")
+
     def test_edit_user_with_invalid_data_test_city(self):
         """
         Se testea la función editar con datos de ciudad invalido.

--- a/app/tests_integration.py
+++ b/app/tests_integration.py
@@ -169,7 +169,7 @@ class ClientsTest(TestCase):
         )
     
 
-        self.client.post(
+        response = self.client.post(
             reverse("clients_form"),
             data={
                 "id": client.id,
@@ -180,9 +180,7 @@ class ClientsTest(TestCase):
             },
         )
 
-        # redirect after post
-        editedClient = Client.objects.get(pk=client.id)
-        self.assertEqual(editedClient.city, "La Plata")
+        self.assertContains(response, "Por favor ingrese una ciudad valida")
 
     def test_validation_invalid_name_client(self):
         """

--- a/app/tests_unit.py
+++ b/app/tests_unit.py
@@ -114,6 +114,20 @@ class ClientModelTest(TestCase):
 
         self.assertEqual(str(client_updated.phone), "54221555232")
 
+    def test_validate_client_incorrect_city(self):
+        """
+        Prueba que verifica que no se pueda crear un cliente con una ciudad que no este en las opciones dadas 
+        """
+        data = {
+            "name": "Juan Sebastian Veron 11",
+            "phone": "54221555232",
+            "city": "Rosario",
+            "email": "brujita75@hotmail.com",
+        }
+
+        result = validate_client(data)
+
+        self.assertIn("Por favor ingrese una ciudad valida", result.values())
 
     def test_validate_client_incorrect_name(self):
         """

--- a/functional_tests/tests.py
+++ b/functional_tests/tests.py
@@ -335,7 +335,7 @@ class ClientCreateEditTestCase(PlaywrightTestCase):
         expect(self.page.get_by_text("El nombre debe contener solo letras y espacios")).to_be_visible()
         
 
-   def test_should_show_message_if_city_is_not_selected(self):
+    def test_should_show_message_if_city_is_not_selected(self):
         """
         Esta función verifica que se muestre un mensaje de error cuando se intenta 
         crear un cliente sin seleccionar ciudad

--- a/functional_tests/tests.py
+++ b/functional_tests/tests.py
@@ -321,26 +321,29 @@ class ClientCreateEditTestCase(PlaywrightTestCase):
         """
         Esta función verifica que muestre un mesnaje de error para un nombre invalido.
         """
-        
         self.page.goto(f"{self.live_server_url}{reverse('clients_form')}")
 
         expect(self.page.get_by_role("form")).to_be_visible()
-        
+
         self.page.get_by_label("Nombre").fill("manu22")
         self.page.get_by_label("Teléfono").fill("54221555232")
         self.page.get_by_label("Email").fill("brujita75@vetsoft.com")
         self.page.get_by_label("Ciudad").select_option("La Plata")
 
         self.page.get_by_role("button", name="Guardar").click()
-        
+
         expect(self.page.get_by_text("El nombre debe contener solo letras y espacios")).to_be_visible()
         
 
-    def test_should_show_message_if_city_is_not_selected(self):
+   def test_should_show_message_if_city_is_not_selected(self):
         """
         Esta función verifica que se muestre un mensaje de error cuando se intenta 
         crear un cliente sin seleccionar ciudad
         """
+        self.page.goto(f"{self.live_server_url}{reverse('clients_form')}")
+
+        expect(self.page.get_by_role("form")).to_be_visible()
+
         self.page.get_by_label("Nombre").fill("Angel")
         self.page.get_by_label("Teléfono").fill("542226836789")
         self.page.get_by_label("Email").fill("fideo@vetsoft.com")

--- a/functional_tests/tests.py
+++ b/functional_tests/tests.py
@@ -316,6 +316,23 @@ class ClientCreateEditTestCase(PlaywrightTestCase):
             "href", reverse("clients_edit", kwargs={"id": client.id}),
         )
 
+    def test_should_show_message_if_city_is_not_selected(self):
+        """
+        Esta función verifica que se muestre un mensaje de error cuando se intenta 
+        crear un cliente sin seleccionar ciudad
+        """
+        self.page.goto(f"{self.live_server_url}{reverse('clients_form')}")
+
+        expect(self.page.get_by_role("form")).to_be_visible()
+
+        self.page.get_by_label("Nombre").fill("Angel")
+        self.page.get_by_label("Teléfono").fill("542226836789")
+        self.page.get_by_label("Email").fill("fideo@vetsoft.com")
+        # no selecciono una ciudad
+        self.page.get_by_role("button", name="Guardar").click()
+
+        # Verifica si se muestra el mensaje de error esperado
+        expect(self.page.get_by_text("Por favor ingrese una ciudad")).to_be_visible()
 
 
 class MedicineCreateEditTestCase(PlaywrightTestCase):


### PR DESCRIPTION
Arreglo test de integración de cliente, que valida la edición con una ciudad inválida.
Se agregaron tests unitarios, e2e y de integración faltantes, que validan la creación de clientes con campos de ciudad inválidos