### PR TITLE
Bugfix/validar email cliente

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -41,9 +41,10 @@ def validate_client(data):
 
     if email == "":
         errors["email"] = "Por favor ingrese un email"
-    elif "@vetsoft.com" not in email:
-        errors["email"] = "El email debe ser de la forma @vetsoft.com"
-
+    elif not re.match(r"^[a-zA-Z0-9._%+-]+@vetsoft\.com$", email):
+        errors["email"] = "El email debe tener un formato válido y ser de la forma nombre@vesoft.com"
+    
+    
     if city == "" or city is None:
         errors["city"] = "Por favor ingrese una ciudad"
     elif city not in dict(CityEnum.choices):

--- a/app/templates/clients/form.html
+++ b/app/templates/clients/form.html
@@ -56,7 +56,7 @@
                     <input type="email"
                         id="email"
                         name="email"
-                        pattern="\w+@vetsoft.com"
+                        pattern="^[\w\.\-]+@vetsoft\.com$"
                         class="form-control"
                         value="{{client.email}}"
                         required/>

--- a/app/tests_integration.py
+++ b/app/tests_integration.py
@@ -92,7 +92,8 @@ class ClientsTest(TestCase):
         response = self.client.get(reverse("clients_edit", kwargs={"id": 100}))
         self.assertEqual(response.status_code, 404)
 
-    def test_validation_invalid_email(self):
+    #Test pra comprobar que tenga texto delante de @vetsoft.com
+    def test_validation_invalid_email_whit_vetsoft(self):
         """
         Esta función testea la validación de emails invalidos.
         """
@@ -102,11 +103,25 @@ class ClientsTest(TestCase):
                 "name": "Juan Sebastian Veron",
                 "phone": 54221555232,
                 "city": "La Plata",
-                "email": "brujita75",
+                "email": "@vetsoft.com",
             },
         )
-        self.assertContains(response, "El email debe ser de la forma @vetsoft.com")
+        self.assertContains(response, "El email debe tener un formato válido y ser de la forma nombre@vesoft.com")
      
+    def test_validation_email_null(self):
+        """
+        Esta función testea la validación de emails invalidos.
+        """
+        response = self.client.post(
+            reverse("clients_form"),
+            data={
+                "name": "Juan Sebastian Veron",
+                "phone": 54221555232,
+                "city": "La Plata",
+                "email": "",
+            },
+        )
+        self.assertContains(response, "Por favor ingrese un email")
 
 
     def test_validation_invalid_phone(self):

--- a/app/tests_integration.py
+++ b/app/tests_integration.py
@@ -96,6 +96,7 @@ class ClientsTest(TestCase):
     def test_validation_invalid_email_whit_vetsoft(self):
         """
         Esta función testea la validación de emails invalidos.
+        agregando la validacion de que deba tener texto delante del @vetsoft.com
         """
         response = self.client.post(
             reverse("clients_form"),
@@ -110,7 +111,7 @@ class ClientsTest(TestCase):
      
     def test_validation_email_null(self):
         """
-        Esta función testea la validación de emails invalidos.
+        Esta función testea la validación de emails nulos.
         """
         response = self.client.post(
             reverse("clients_form"),

--- a/app/tests_unit.py
+++ b/app/tests_unit.py
@@ -215,6 +215,30 @@ class ClientModelTest(TestCase):
 
         self.assertEqual(client_updated.name, "Juan Sebastian Veron")
 
+    def test_invalid_email_no_text_before_at(self):
+        #Test agregado del email del cliente
+        data = {
+                "name": "Gonza",
+                "phone": "54221555232",
+                "city": "La Plata",
+                "email": "@vetsoft.com",
+            }
+        errors = validate_client(data)
+ 
+        self.assertIn("El email debe tener un formato válido y ser de la forma nombre@vesoft.com", errors.values())
+
+    def test_invalid_email_not_ending_with_com(self):
+        data = {
+                "name": "Gonza",
+                "phone": "54221555232",
+                "city": "La Plata",
+                "email": "gonza@vetsoft.net",
+            }
+        errors = validate_client(data)
+ 
+        self.assertIn("El email debe tener un formato válido y ser de la forma nombre@vesoft.com", errors.values())
+
+
 class MedicineModelTest(TestCase):
     """
     Pruebas para el modelo Medicina.

--- a/app/tests_unit.py
+++ b/app/tests_unit.py
@@ -216,7 +216,10 @@ class ClientModelTest(TestCase):
         self.assertEqual(client_updated.name, "Juan Sebastian Veron")
 
     def test_invalid_email_no_text_before_at(self):
-        #Test agregado del email del cliente
+        """
+        Test agregado del email del cliente
+        Verifica que deba haber texto delante del @vetsoft
+        """
         data = {
                 "name": "Gonza",
                 "phone": "54221555232",
@@ -228,6 +231,10 @@ class ClientModelTest(TestCase):
         self.assertIn("El email debe tener un formato válido y ser de la forma nombre@vesoft.com", errors.values())
 
     def test_invalid_email_not_ending_with_com(self):
+
+        """
+        Verifica que el correo termine en .com, por mas de que ingrese un email valido cotidianamente.
+        """
         data = {
                 "name": "Gonza",
                 "phone": "54221555232",

--- a/app/views.py
+++ b/app/views.py
@@ -1,4 +1,5 @@
-from django.shortcuts import get_object_or_404, redirect, render, reverse
+from django.shortcuts import get_object_or_404, redirect, render
+from django.urls import reverse
 
 from .models import CityEnum, Client, Medicine, Pet, Product, Provider, Veterinary
 
@@ -38,10 +39,11 @@ def clients_form(request, id=None):
                 saved = True
 
         if saved:
+            """print("Saved successfully! Redirecting to clients_repo...")"""
             return redirect(reverse("clients_repo"))
-
-        return render(
-            request, "clients/form.html", {"errors": errors, "client": request.POST, "ciudades": ciudades},)
+        else:
+            """print("Error saving client! Errors:", errors"""
+            return render(request, "clients/form.html", {"errors": errors, "client": request.POST, "ciudades": ciudades})
 
     client = None
     if id is not None:

--- a/functional_tests/tests.py
+++ b/functional_tests/tests.py
@@ -276,7 +276,7 @@ class ClientCreateEditTestCase(PlaywrightTestCase):
         ).not_to_be_visible()
 
         expect(
-            self.page.get_by_text("El email debe ser de la forma @vetsoft.com"),
+            self.page.get_by_text("El email debe tener un formato válido y ser de la forma nombre@vesoft.com"),
         ).to_be_visible()
 
     def test_should_be_able_to_edit_a_client(self):
@@ -316,7 +316,61 @@ class ClientCreateEditTestCase(PlaywrightTestCase):
             "href", reverse("clients_edit", kwargs={"id": client.id}),
         )
 
+    #Tests agregados para validacion de email.
+    def test_should_view_errors_if_form_is_invalid_email(self):
+        """
+        Esta función  verifica que se muestren los errores de validación en el email del
+        formulario si se envían datos inválidos al intentar crear un nuevo cliente.
+        """
+        self.page.goto(f"{self.live_server_url}{reverse('clients_form')}")
 
+        expect(self.page.get_by_role("form")).to_be_visible()
+
+        #Ingreso datos vacios
+        self.page.get_by_role("button", name="Guardar").click()
+
+        expect(self.page.get_by_text("Por favor ingrese un nombre")).to_be_visible()
+        expect(self.page.get_by_text("Por favor ingrese un teléfono")).to_be_visible()
+        expect(self.page.get_by_text("Por favor ingrese un email")).to_be_visible()
+        expect(self.page.get_by_text("Por favor ingrese una ciudad")).to_be_visible()
+
+        #Ingreso un email vacio
+        self.page.get_by_label("Nombre").fill("Gonzalo")
+        self.page.get_by_label("Teléfono").fill("54221555232")
+        self.page.get_by_label("Email").fill("")
+        self.page.get_by_label("Ciudad").select_option("La Plata")
+
+        self.page.get_by_role("button", name="Guardar").click()
+
+        expect(self.page.get_by_text("Por favor ingrese un nombre")).not_to_be_visible()
+        expect(self.page.get_by_text("Por favor ingrese un teléfono")).not_to_be_visible()
+        expect(self.page.get_by_text("Por favor ingrese una ciudad")).not_to_be_visible()
+        expect(self.page.get_by_text("Por favor ingrese un email")).to_be_visible()
+
+        # Ingresar un email erróneo
+        self.page.get_by_label("Nombre").fill("Gonzalo")
+        self.page.get_by_label("Teléfono").fill("54221555232")
+        self.page.get_by_label("Email").fill("@vetsoft.net")
+        self.page.get_by_label("Ciudad").select_option("La Plata")
+
+        self.page.get_by_role("button", name="Guardar").click()
+
+        expect(self.page.get_by_text("Por favor ingrese un email")).not_to_be_visible()
+        expect(self.page.get_by_text("El email debe tener un formato válido y ser de la forma nombre@vesoft.com")).to_be_visible()
+
+        # Ingreso un email válido
+        self.page.get_by_label("Nombre").fill("Gonzalo")
+        self.page.get_by_label("Teléfono").fill("54221555232")
+        self.page.get_by_label("Email").fill("gonza@vetsoft.com")
+        self.page.get_by_label("Ciudad").select_option("La Plata")
+    
+        self.page.get_by_role("button", name="Guardar").click()
+
+        expect(self.page.get_by_text("Gonzalo")).to_be_visible()
+        expect(self.page.get_by_text("54221555232")).to_be_visible()
+        expect(self.page.get_by_text("gonza@vetsoft.com")).to_be_visible()
+        expect(self.page.get_by_text("La Plata")).to_be_visible()
+        
 
 class MedicineCreateEditTestCase(PlaywrightTestCase):
     """


### PR DESCRIPTION
Corrijo los bugs de que permita escribir un correo sin texto delante de @vetsoft.com
Agregamos tests para verificar que obligatoriamente deba poner un email valido. 